### PR TITLE
Fix MCP config to use Unity HTTP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,7 @@
 {
   "mcpServers": {
     "unityMCP": {
-      "command": "uvx",
-      "args": ["--from", "mcpforunityserver", "mcp-for-unity", "--transport", "stdio"]
+      "url": "http://127.0.0.1:8080/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Switch `.mcp.json` from spawning a separate stdio MCP server to connecting to the existing HTTP server at `http://127.0.0.1:8080/mcp`
- Fixes issue where Claude Code's MCP bridge couldn't see the Unity instance because Unity was registered with a different (HTTP) server process

## Test plan
- [ ] Restart Conductor/Claude Code session
- [ ] Verify Unity MCP tools can discover the Unity instance
- [ ] Confirm scene hierarchy and editor state queries work

🤖 Generated with [Claude Code](https://claude.com/claude-code)