### PR TITLE
feat(voice): self-similar voice launch mode (Mistral Voxtral)

### DIFF
--- a/Assets/SessionConfig.cs
+++ b/Assets/SessionConfig.cs
@@ -2,6 +2,17 @@ using System.IO;
 using UnityEngine;
 
 /// <summary>
+/// Which voice the assistant speaks in for this run.
+///   Generic    = the fixed ElevenLabs voice (existing behavior).
+///   SelfSimilar = a voice cloned from the participant via Mistral Voxtral.
+/// </summary>
+public enum VoiceCondition
+{
+    Generic,
+    SelfSimilar
+}
+
+/// <summary>
 /// Shared session configuration for data logging.
 /// Manages participant IDs, run numbering, and folder structure.
 ///
@@ -37,6 +48,22 @@ public static class SessionConfig
     /// <summary>The condition label for the current run.</summary>
     public static string ConditionLabel { get; private set; } = "";
 
+    /// <summary>Voice condition for this run. Set before game start (default Generic).</summary>
+    public static VoiceCondition Voice { get; set; } = VoiceCondition.Generic;
+
+    /// <summary>
+    /// Mistral Voxtral voice id for the self-similar clone (set at enrollment).
+    /// Empty until a voice has been cloned this session.
+    /// </summary>
+    public static string SelfSimilarVoiceId { get; set; } = "";
+
+    /// <summary>
+    /// True while a self-similar voice is being recorded/cloned. While pending,
+    /// the synthesizer stays silent rather than leaking the generic voice into a
+    /// run labeled self-similar.
+    /// </summary>
+    public static bool SelfSimilarEnrollmentPending { get; set; } = false;
+
     /// <summary>Root data folder path.</summary>
     public static string RootPath => Path.Combine(Application.persistentDataPath, k_RootFolder);
 
@@ -64,6 +91,13 @@ public static class SessionConfig
         ConditionLabel = string.IsNullOrWhiteSpace(conditionLabel)
             ? "unspecified"
             : conditionLabel;
+
+        // Record the voice condition in the folder name so runs are self-describing.
+        string voiceTag = Voice == VoiceCondition.SelfSimilar ? "selfsimilar" : "generic";
+        ConditionLabel = $"{ConditionLabel}_voice-{voiceTag}";
+
+        // Reset any stale run state that also resets the session should clear the
+        // cloned voice id (handled by ResetForNewParticipant).
 
         // Find next run number for this participant
         string participantDir = Path.Combine(RootPath, ParticipantId);
@@ -108,6 +142,8 @@ public static class SessionConfig
         RunNumber = 0;
         CurrentRunFolder = "";
         ConditionLabel = "";
+        // A cloned voice belongs to one participant — force re-enrollment for the next.
+        SelfSimilarVoiceId = "";
     }
 
     /// <summary>

--- a/Assets/VoiceAssistantController.cs
+++ b/Assets/VoiceAssistantController.cs
@@ -97,6 +97,7 @@ public class VoiceAssistantController : MonoBehaviour
     IEnumerator LoadKeys()
     {
         string elevenLabsKey = "";
+        string mistralKey = "";
         string keysPath = System.IO.Path.Combine(Application.streamingAssetsPath, k_KeysFile);
 
         string url = keysPath;
@@ -111,6 +112,7 @@ public class VoiceAssistantController : MonoBehaviour
             {
                 var keys = JsonUtility.FromJson<ApiKeys>(request.downloadHandler.text);
                 elevenLabsKey = keys.elevenlabs_key;
+                mistralKey = keys.mistral_key;
                 Debug.Log($"{k_Tag} Loaded API keys");
             }
             else
@@ -119,9 +121,15 @@ public class VoiceAssistantController : MonoBehaviour
             }
         }
 
-        // Initialize sub-systems with the loaded key
-        m_VoiceSynthesizer.Initialize(elevenLabsKey);
+        // Initialize sub-systems with the loaded keys
+        m_VoiceSynthesizer.Initialize(elevenLabsKey, mistralKey);
         m_HintGenerator.Initialize(elevenLabsKey, m_AgentContext, m_VoiceSynthesizer, m_CoverageTracker);
+
+        // Self-similar voice: enrollment (mic -> clone) + the on-entry mode picker.
+        var enrollment = gameObject.AddComponent<VoiceEnrollment>();
+        enrollment.Initialize(m_VoiceSynthesizer.Voxtral);
+        var modeSelector = gameObject.AddComponent<VoiceModeSelector>();
+        modeSelector.Initialize(enrollment);
 
         IsReady = true;
         Debug.Log($"{k_Tag} Ready. Key={(!string.IsNullOrEmpty(elevenLabsKey) ? "present" : "MISSING")}");
@@ -330,6 +338,7 @@ public class VoiceAssistantController : MonoBehaviour
     struct ApiKeys
     {
         public string elevenlabs_key;
+        public string mistral_key;
     }
 
     static AudioClip CreateWrongCaptureCue()

--- a/Assets/VoiceEnrollment.cs
+++ b/Assets/VoiceEnrollment.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections;
+using UnityEngine;
+#if UNITY_ANDROID
+using UnityEngine.Android;
+#endif
+
+/// <summary>
+/// Records a short microphone sample and clones it via <see cref="VoxtralClient"/>,
+/// storing the resulting voice id in <see cref="SessionConfig.SelfSimilarVoiceId"/>.
+/// Drives the self-similar launch mode's enrollment step.
+/// </summary>
+public class VoiceEnrollment : MonoBehaviour
+{
+    const string k_Tag = "[Enroll]";
+    const int k_SampleRate = 16000;   // mono 16 kHz keeps the base64 sample small
+    const int k_DefaultSeconds = 40;
+
+    VoxtralClient m_Voxtral;
+    AudioClip m_RecordingClip;
+    bool m_Busy;
+
+    public enum State { Idle, Recording, Cloning, Done, Failed }
+    public State Current { get; private set; } = State.Idle;
+    public string LastError { get; private set; } = "";
+    public bool IsBusy => m_Busy;
+
+    public void Initialize(VoxtralClient voxtral)
+    {
+        m_Voxtral = voxtral != null ? voxtral : GetComponent<VoxtralClient>();
+        if (m_Voxtral == null)
+            Debug.LogWarning($"{k_Tag} No VoxtralClient supplied — enrollment will fail.");
+    }
+
+    /// <summary>
+    /// Records <paramref name="seconds"/> of audio, clones it, and sets
+    /// SessionConfig.SelfSimilarVoiceId. Reports progress via optional callbacks.
+    /// </summary>
+    public void RecordAndClone(int seconds = k_DefaultSeconds,
+        Action<State> onState = null, Action<string> onDone = null, Action<string> onError = null)
+    {
+        if (m_Busy) { onError?.Invoke("enrollment already running"); return; }
+        StartCoroutine(RecordAndCloneCoroutine(seconds, onState, onDone, onError));
+    }
+
+    IEnumerator RecordAndCloneCoroutine(int seconds,
+        Action<State> onState, Action<string> onDone, Action<string> onError)
+    {
+        m_Busy = true;
+        void Set(State s) { Current = s; onState?.Invoke(s); }
+
+        // Mic permission (Android/Quest/Vive).
+#if UNITY_ANDROID
+        if (!Permission.HasUserAuthorizedPermission(Permission.Microphone))
+        {
+            Permission.RequestUserPermission(Permission.Microphone);
+            float waited = 0f;
+            while (!Permission.HasUserAuthorizedPermission(Permission.Microphone) && waited < 20f)
+            { waited += Time.deltaTime; yield return null; }
+        }
+#endif
+        if (Microphone.devices == null || Microphone.devices.Length == 0)
+        {
+            Fail("no microphone device", onError); Set(State.Failed); m_Busy = false; yield break;
+        }
+
+        Set(State.Recording);
+        Debug.Log($"{k_Tag} Recording {seconds}s...");
+        m_RecordingClip = Microphone.Start(null, false, Mathf.Clamp(seconds, 10, 60), k_SampleRate);
+        if (m_RecordingClip == null)
+        {
+            Fail("Microphone.Start returned null", onError); Set(State.Failed); m_Busy = false; yield break;
+        }
+
+        float t = 0f;
+        while (t < seconds && Microphone.IsRecording(null))
+        { t += Time.deltaTime; yield return null; }
+
+        int recordedSamples = Microphone.GetPosition(null);
+        Microphone.End(null);
+
+        byte[] wav = WavUtility.EncodeFromClip(m_RecordingClip, recordedSamples);
+        Debug.Log($"{k_Tag} Encoded WAV: {wav.Length} bytes ({recordedSamples} samples)");
+
+        Set(State.Cloning);
+        string voiceId = null; string err = null;
+        yield return m_Voxtral.CloneVoice(wav, $"study_{SessionConfig.ParticipantId}",
+            id => voiceId = id, e => err = e);
+
+        if (!string.IsNullOrEmpty(voiceId))
+        {
+            SessionConfig.SelfSimilarVoiceId = voiceId;
+            Set(State.Done);
+            Debug.Log($"{k_Tag} Enrollment complete. voiceId={voiceId}");
+            onDone?.Invoke(voiceId);
+        }
+        else
+        {
+            Fail(err ?? "clone failed", onError); Set(State.Failed);
+        }
+        m_Busy = false;
+    }
+
+    void Fail(string msg, Action<string> onError)
+    {
+        LastError = msg;
+        Debug.LogWarning($"{k_Tag} {msg}");
+        onError?.Invoke(msg);
+    }
+}

--- a/Assets/VoiceEnrollment.cs.meta
+++ b/Assets/VoiceEnrollment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2aef9cd6e80bc41e596470b73a9ba41b

--- a/Assets/VoiceModeSelector.cs
+++ b/Assets/VoiceModeSelector.cs
@@ -1,0 +1,200 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.XR;
+using TMPro;
+
+/// <summary>
+/// On-entry launch-mode picker: choose Standard (generic ElevenLabs) or
+/// Self-Similar (Voxtral clone of the participant) voice. Shown once at startup
+/// as a small world-space panel in front of the camera.
+///
+/// Selection:
+///   Trigger  or keyboard [1]  -> Standard voice   (SessionConfig.Voice = Generic)
+///   A/Primary or keyboard [2] -> Self-Similar     (records + clones, then continues)
+///
+/// The researcher may also just call SelectGeneric()/SelectSelfSimilar() or set
+/// the default in the inspector (m_DefaultMode) and skip the panel via m_AutoConfirmDefault.
+/// </summary>
+public class VoiceModeSelector : MonoBehaviour
+{
+    const string k_Tag = "[VoiceMode]";
+
+    [Header("Optional overrides")]
+    [SerializeField] VoiceCondition m_DefaultMode = VoiceCondition.Generic;
+    [SerializeField] bool m_AutoConfirmDefault = false; // skip the panel, use m_DefaultMode
+    [SerializeField] int m_RecordSeconds = 40;
+
+    enum Phase { Choosing, Enrolling, Done }
+    Phase m_Phase = Phase.Choosing;
+
+    VoiceEnrollment m_Enrollment;
+    Canvas m_Canvas;
+    GameObject m_CanvasGO;
+    TextMeshProUGUI m_Text;
+    readonly List<InputDevice> m_Devices = new List<InputDevice>();
+    bool m_FirstPoll = true;
+    bool m_PrevTrigger;
+    bool m_PrevPrimary;
+
+    public void Initialize(VoiceEnrollment enrollment)
+    {
+        m_Enrollment = enrollment;
+
+        if (m_AutoConfirmDefault)
+        {
+            if (m_DefaultMode == VoiceCondition.SelfSimilar) SelectSelfSimilar();
+            else SelectGeneric();
+            return;
+        }
+
+        BuildPanel();
+        SetText("<b>Voice mode</b>\n\nPull <b>Trigger</b> (or press 1):  Standard voice\n" +
+                "Press <b>A / X</b> (or press 2):  Use my voice");
+    }
+
+    void BuildPanel()
+    {
+        m_CanvasGO = new GameObject("VoiceModeCanvas");
+        var cam = Camera.main;
+        if (cam != null) m_CanvasGO.transform.SetParent(cam.transform, false);
+        m_CanvasGO.transform.localPosition = new Vector3(0f, 0f, 1.2f);
+        m_CanvasGO.transform.localRotation = Quaternion.identity;
+
+        m_Canvas = m_CanvasGO.AddComponent<Canvas>();
+        m_Canvas.renderMode = RenderMode.WorldSpace;
+        var rect = m_CanvasGO.GetComponent<RectTransform>();
+        rect.sizeDelta = new Vector2(700, 360);
+        m_CanvasGO.transform.localScale = Vector3.one * 0.0011f;
+
+        var bg = new GameObject("Bg");
+        bg.transform.SetParent(m_CanvasGO.transform, false);
+        var bgRect = bg.AddComponent<RectTransform>();
+        bgRect.sizeDelta = new Vector2(700, 360);
+        bg.AddComponent<UnityEngine.UI.Image>().color = new Color(0f, 0f, 0f, 0.82f);
+
+        var textGO = new GameObject("Text");
+        textGO.transform.SetParent(m_CanvasGO.transform, false);
+        var tRect = textGO.AddComponent<RectTransform>();
+        tRect.sizeDelta = new Vector2(660, 320);
+        m_Text = textGO.AddComponent<TextMeshProUGUI>();
+        m_Text.alignment = TextAlignmentOptions.Center;
+        m_Text.fontSize = 34;
+        m_Text.color = new Color(0.9f, 0.97f, 1f, 1f);
+    }
+
+    void SetText(string s) { if (m_Text != null) m_Text.text = s; }
+
+    void Update()
+    {
+        // Keep the panel in front of the camera if we couldn't parent at build time.
+        if (m_CanvasGO != null && m_CanvasGO.transform.parent == null)
+        {
+            var cam = Camera.main;
+            if (cam != null)
+            {
+                m_CanvasGO.transform.position = cam.transform.position + cam.transform.forward * 1.2f;
+                m_CanvasGO.transform.rotation = Quaternion.LookRotation(m_CanvasGO.transform.position - cam.transform.position);
+            }
+        }
+
+        if (m_Phase != Phase.Choosing) return;
+
+        bool trig = ReadTrigger();
+        bool prim = ReadPrimary();
+
+        // Ignore any button already held when the panel first appears, so a
+        // trigger held from the previous screen can't auto-select.
+        if (m_FirstPoll)
+        {
+            m_PrevTrigger = trig; m_PrevPrimary = prim; m_FirstPoll = false;
+            return;
+        }
+
+        bool trigEdge = trig && !m_PrevTrigger;   // rising edge only
+        bool primEdge = prim && !m_PrevPrimary;
+        m_PrevTrigger = trig; m_PrevPrimary = prim;
+
+        if (trigEdge || KeyPressed(1)) { SelectGeneric(); return; }
+        if (primEdge || KeyPressed(2)) { SelectSelfSimilar(); return; }
+    }
+
+    public void SelectGeneric()
+    {
+        SessionConfig.Voice = VoiceCondition.Generic;
+        Debug.Log($"{k_Tag} Standard voice selected");
+        Finish("Standard voice selected.");
+    }
+
+    public void SelectSelfSimilar()
+    {
+        SessionConfig.Voice = VoiceCondition.SelfSimilar;
+        Debug.Log($"{k_Tag} Self-similar voice selected — enrolling");
+        m_Phase = Phase.Enrolling;
+        SetText("<b>Recording your voice…</b>\n\nPlease read aloud steadily for about " +
+                m_RecordSeconds + " seconds.");
+
+        if (m_Enrollment == null)
+        {
+            SetText("Voice enrollment unavailable — using standard voice.");
+            SessionConfig.Voice = VoiceCondition.Generic;
+            SessionConfig.SelfSimilarEnrollmentPending = false;
+            Finish("Standard voice (enrollment unavailable).");
+            return;
+        }
+
+        // Gate the synthesizer to silence (not generic) until the clone is ready.
+        SessionConfig.SelfSimilarEnrollmentPending = true;
+
+        m_Enrollment.RecordAndClone(
+            m_RecordSeconds,
+            onState: s =>
+            {
+                if (s == VoiceEnrollment.State.Cloning) SetText("<b>Creating your voice…</b>\nOne moment.");
+            },
+            onDone: _ =>
+            {
+                SessionConfig.SelfSimilarEnrollmentPending = false;
+                Finish("Your voice is ready.");
+            },
+            onError: err =>
+            {
+                Debug.LogWarning($"{k_Tag} Enrollment failed: {err}; falling back to standard voice");
+                SessionConfig.Voice = VoiceCondition.Generic;
+                SessionConfig.SelfSimilarEnrollmentPending = false;
+                Finish("Could not create your voice — using standard voice.");
+            });
+    }
+
+    void Finish(string message)
+    {
+        m_Phase = Phase.Done;
+        SetText(message + "\n\nTap a nearby surface to begin.");
+        // Leave the confirmation up briefly, then remove the panel.
+        if (m_CanvasGO != null) Destroy(m_CanvasGO, 3.0f);
+        enabled = false;
+    }
+
+    // --- XR controller input (headset) ---
+    bool ReadTrigger()  => ReadButton(CommonUsages.triggerButton);
+    bool ReadPrimary()  => ReadButton(CommonUsages.primaryButton);
+
+    bool ReadButton(InputFeatureUsage<bool> usage)
+    {
+        InputDevices.GetDevicesWithCharacteristics(InputDeviceCharacteristics.Controller, m_Devices);
+        foreach (var d in m_Devices)
+            if (d.TryGetFeatureValue(usage, out bool pressed) && pressed) return true;
+        return false;
+    }
+
+    // --- Keyboard fallback for editor testing ---
+    bool KeyPressed(int digit)
+    {
+#if ENABLE_INPUT_SYSTEM
+        var kb = UnityEngine.InputSystem.Keyboard.current;
+        if (kb == null) return false;
+        return digit == 1 ? kb.digit1Key.wasPressedThisFrame : kb.digit2Key.wasPressedThisFrame;
+#else
+        return Input.GetKeyDown(digit == 1 ? KeyCode.Alpha1 : KeyCode.Alpha2);
+#endif
+    }
+}

--- a/Assets/VoiceModeSelector.cs.meta
+++ b/Assets/VoiceModeSelector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6c0a2eabbef14991bf2afbfc9992924

--- a/Assets/VoiceSynthesizer.cs
+++ b/Assets/VoiceSynthesizer.cs
@@ -17,7 +17,9 @@ public class VoiceSynthesizer : MonoBehaviour
     const string k_Model = "eleven_turbo_v2_5";
     const string k_CacheFolder = "tts_cache";
 
-    string m_ApiKey;
+    string m_ApiKey;        // ElevenLabs key (generic voice)
+    string m_MistralKey;    // Voxtral key (self-similar voice)
+    VoxtralClient m_Voxtral;
     string m_CacheDir;
     AudioSource m_AudioSource;
     Coroutine m_SpeakCoroutine;
@@ -26,9 +28,17 @@ public class VoiceSynthesizer : MonoBehaviour
     public bool IsSpeaking => m_AudioSource != null && m_AudioSource.isPlaying;
     public bool IsBusy => m_SpeakCoroutine != null || IsSpeaking;
 
-    public void Initialize(string apiKey)
+    /// <summary>Shared Voxtral client (voice enrollment reuses this instance).</summary>
+    public VoxtralClient Voxtral => m_Voxtral;
+
+    public void Initialize(string elevenLabsKey, string mistralKey = null)
     {
-        m_ApiKey = apiKey;
+        m_ApiKey = elevenLabsKey;
+        m_MistralKey = mistralKey;
+
+        m_Voxtral = GetComponent<VoxtralClient>();
+        if (m_Voxtral == null) m_Voxtral = gameObject.AddComponent<VoxtralClient>();
+        m_Voxtral.Initialize(mistralKey);
 
         m_AudioSource = gameObject.AddComponent<AudioSource>();
         m_AudioSource.spatialBlend = 0f;
@@ -45,12 +55,8 @@ public class VoiceSynthesizer : MonoBehaviour
 
     public void Speak(string text, string context = null)
     {
-        if (string.IsNullOrEmpty(m_ApiKey))
-        {
-            Debug.LogWarning($"{k_Tag} No API key, skipping TTS");
-            return;
-        }
-
+        // Per-voice key checks happen inside the coroutine (self-similar uses
+        // Voxtral, generic uses ElevenLabs), so we don't hard-block here.
         Stop();
         m_CurrentContext = context;
         m_SpeakCoroutine = StartCoroutine(SpeakCoroutine(text));
@@ -82,66 +88,110 @@ public class VoiceSynthesizer : MonoBehaviour
 
     IEnumerator SpeakCoroutine(string text)
     {
-        string cachePath = GetCachePath(text);
+        bool wantSelfSimilar =
+            SessionConfig.Voice == VoiceCondition.SelfSimilar &&
+            !string.IsNullOrEmpty(SessionConfig.SelfSimilarVoiceId) &&
+            m_Voxtral != null && m_Voxtral.HasKey;
 
-        // Check cache first
+        // If a self-similar clone is still being recorded/cloned, stay silent
+        // rather than leak the generic voice into a self-similar-labeled run.
+        if (SessionConfig.Voice == VoiceCondition.SelfSimilar &&
+            string.IsNullOrEmpty(SessionConfig.SelfSimilarVoiceId) &&
+            SessionConfig.SelfSimilarEnrollmentPending)
+        {
+            Debug.Log($"{k_Tag} Self-similar enrollment pending; suppressing \"{Truncate(text, 40)}\"");
+            m_SpeakCoroutine = null;
+            m_CurrentContext = null;
+            yield break;
+        }
+
+        // 1) Cache for the intended voice.
+        string cachePath = GetCachePath(text, wantSelfSimilar);
         if (File.Exists(cachePath))
         {
-            Debug.Log($"{k_Tag} Cache hit: \"{Truncate(text, 40)}\"");
+            Debug.Log($"{k_Tag} Cache hit ({(wantSelfSimilar ? "self" : "generic")}): \"{Truncate(text, 40)}\"");
             yield return PlayFromFile(cachePath);
             m_SpeakCoroutine = null;
             m_CurrentContext = null;
             yield break;
         }
 
-        // Cache miss — download from ElevenLabs
-        Debug.Log($"{k_Tag} Cache miss, requesting TTS: \"{Truncate(text, 40)}\"");
+        byte[] audioData = null;
 
-        string url = $"{k_BaseUrl}{k_VoiceId}";
-        string jsonBody = JsonUtility.ToJson(new TtsRequest
+        // 2) Synthesize the intended voice (Voxtral for self-similar).
+        if (wantSelfSimilar)
         {
-            text = text,
-            model_id = k_Model
-        });
-
-        var request = new UnityWebRequest(url, "POST");
-        byte[] bodyRaw = System.Text.Encoding.UTF8.GetBytes(jsonBody);
-        request.uploadHandler = new UploadHandlerRaw(bodyRaw);
-        request.downloadHandler = new DownloadHandlerBuffer();
-        request.SetRequestHeader("Content-Type", "application/json");
-        request.SetRequestHeader("xi-api-key", m_ApiKey);
-        request.timeout = 15;
-
-        yield return request.SendWebRequest();
-
-        if (request.result != UnityWebRequest.Result.Success)
-        {
-            string body = request.downloadHandler?.text ?? "";
-            Debug.LogWarning($"{k_Tag} TTS failed: {request.error} (HTTP {request.responseCode}) {body}");
-            m_SpeakCoroutine = null;
-            yield break;
+            Debug.Log($"{k_Tag} Voxtral TTS: \"{Truncate(text, 40)}\"");
+            string vxErr = null;
+            yield return m_Voxtral.Synthesize(text, SessionConfig.SelfSimilarVoiceId,
+                b => audioData = b, e => vxErr = e);
+            if (audioData == null)
+                Debug.LogWarning($"{k_Tag} Voxtral TTS failed ({vxErr}); falling back to generic voice");
         }
 
-        byte[] mp3Data = request.downloadHandler.data;
-        if (mp3Data == null || mp3Data.Length < 100)
+        // 3) Generic ElevenLabs path — primary for Generic mode, fallback otherwise.
+        if (audioData == null)
+        {
+            cachePath = GetCachePath(text, false);
+            if (File.Exists(cachePath))
+            {
+                yield return PlayFromFile(cachePath);
+                m_SpeakCoroutine = null;
+                m_CurrentContext = null;
+                yield break;
+            }
+
+            if (string.IsNullOrEmpty(m_ApiKey))
+            {
+                Debug.LogWarning($"{k_Tag} No ElevenLabs key, skipping TTS");
+                m_SpeakCoroutine = null;
+                m_CurrentContext = null;
+                yield break;
+            }
+
+            Debug.Log($"{k_Tag} ElevenLabs TTS: \"{Truncate(text, 40)}\"");
+            string url = $"{k_BaseUrl}{k_VoiceId}";
+            string jsonBody = JsonUtility.ToJson(new TtsRequest { text = text, model_id = k_Model });
+
+            var request = new UnityWebRequest(url, "POST");
+            request.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(jsonBody));
+            request.downloadHandler = new DownloadHandlerBuffer();
+            request.SetRequestHeader("Content-Type", "application/json");
+            request.SetRequestHeader("xi-api-key", m_ApiKey);
+            request.timeout = 15;
+
+            yield return request.SendWebRequest();
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                string body = request.downloadHandler?.text ?? "";
+                Debug.LogWarning($"{k_Tag} TTS failed: {request.error} (HTTP {request.responseCode}) {body}");
+                m_SpeakCoroutine = null;
+                m_CurrentContext = null;
+                yield break;
+            }
+            audioData = request.downloadHandler.data;
+        }
+
+        if (audioData == null || audioData.Length < 100)
         {
             Debug.LogWarning($"{k_Tag} TTS returned empty audio");
             m_SpeakCoroutine = null;
+            m_CurrentContext = null;
             yield break;
         }
 
-        // Save to cache
+        // Save to cache (path matches whichever voice actually produced the audio).
         try
         {
-            File.WriteAllBytes(cachePath, mp3Data);
-            Debug.Log($"{k_Tag} Cached: \"{Truncate(text, 40)}\" ({mp3Data.Length} bytes)");
+            File.WriteAllBytes(cachePath, audioData);
+            Debug.Log($"{k_Tag} Cached: \"{Truncate(text, 40)}\" ({audioData.Length} bytes)");
         }
         catch (Exception e)
         {
             Debug.LogWarning($"{k_Tag} Failed to cache: {e.Message}");
         }
 
-        // Play from cached file
         yield return PlayFromFile(cachePath);
 
         m_SpeakCoroutine = null;
@@ -194,7 +244,7 @@ public class VoiceSynthesizer : MonoBehaviour
 
         foreach (string phrase in phrases)
         {
-            string path = GetCachePath(phrase);
+            string path = GetCachePath(phrase, false); // pre-cache targets the generic voice
             if (File.Exists(path))
             {
                 skipped++;
@@ -245,11 +295,14 @@ public class VoiceSynthesizer : MonoBehaviour
     /// Generates a deterministic cache file path from the text content.
     /// Uses a simple hash to avoid filesystem issues with long/special-char filenames.
     /// </summary>
-    string GetCachePath(string text)
+    string GetCachePath(string text, bool selfSimilar)
     {
-        // Stable hash: FNV-1a
+        // Scope the key by voice so generic vs self-similar (and different clones)
+        // never collide on identical hint text. FNV-1a over "scope|text".
+        string scope = selfSimilar ? $"vx-{SessionConfig.SelfSimilarVoiceId}" : "el";
+        string keyed = scope + "|" + text;
         uint hash = 2166136261;
-        foreach (char c in text)
+        foreach (char c in keyed)
         {
             hash ^= c;
             hash *= 16777619;

--- a/Assets/VoxtralClient.cs
+++ b/Assets/VoxtralClient.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary>
+/// Thin client for Mistral Voxtral: clone a voice from an audio sample and
+/// synthesize speech from a cloned voice id. Ported from the speedreadify
+/// implementation (voice-clone/route.ts, voxtral-tts.ts).
+///
+/// NOTE: This is a cloud service. Using it with real participant voices sends
+/// identifiable audio to api.mistral.ai and stores the clone on Mistral's
+/// servers — that requires an approved IRB modification. For dev/testing with
+/// the researcher's own voice it is fine.
+/// </summary>
+public class VoxtralClient : MonoBehaviour
+{
+    const string k_Tag = "[Voxtral]";
+    const string k_CloneUrl = "https://api.mistral.ai/v1/audio/voices";
+    const string k_SpeechUrl = "https://api.mistral.ai/v1/audio/speech";
+    const string k_TtsModel = "voxtral-mini-tts-2603";
+
+    string m_ApiKey;
+
+    public bool HasKey => !string.IsNullOrEmpty(m_ApiKey);
+
+    public void Initialize(string apiKey)
+    {
+        m_ApiKey = apiKey;
+        Debug.Log($"{k_Tag} Initialized. Key={(HasKey ? "present" : "MISSING")}");
+    }
+
+    /// <summary>
+    /// Clone a voice from a WAV byte buffer. Calls onVoiceId with the Mistral
+    /// voice id on success, or onError with a message on failure.
+    /// </summary>
+    public IEnumerator CloneVoice(byte[] wavBytes, string displayName,
+        Action<string> onVoiceId, Action<string> onError)
+    {
+        if (!HasKey) { onError?.Invoke("no Mistral API key"); yield break; }
+        if (wavBytes == null || wavBytes.Length < 1000) { onError?.Invoke("sample too small"); yield break; }
+
+        string sampleB64 = Convert.ToBase64String(wavBytes);
+        string body = JsonUtility.ToJson(new CloneRequest
+        {
+            name = string.IsNullOrEmpty(displayName) ? "study_participant" : displayName,
+            sample_audio = sampleB64,
+            sample_filename = "sample.wav"
+        });
+
+        using (var req = new UnityWebRequest(k_CloneUrl, "POST"))
+        {
+            req.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(body));
+            req.downloadHandler = new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+            req.SetRequestHeader("Authorization", $"Bearer {m_ApiKey}");
+            req.timeout = 60;
+
+            Debug.Log($"{k_Tag} Cloning voice ({wavBytes.Length} bytes)...");
+            yield return req.SendWebRequest();
+
+            if (req.result != UnityWebRequest.Result.Success)
+            {
+                onError?.Invoke($"clone HTTP {req.responseCode}: {req.error} {req.downloadHandler?.text}");
+                yield break;
+            }
+
+            string id = null;
+            try { id = JsonUtility.FromJson<IdResponse>(req.downloadHandler.text).id; }
+            catch (Exception e) { onError?.Invoke($"clone parse failed: {e.Message}"); yield break; }
+
+            if (string.IsNullOrEmpty(id)) { onError?.Invoke("clone returned no id"); yield break; }
+            Debug.Log($"{k_Tag} Cloned voice id={id}");
+            onVoiceId?.Invoke(id);
+        }
+    }
+
+    /// <summary>
+    /// Synthesize <paramref name="text"/> in the cloned voice. Returns audio
+    /// bytes (MP3) via onAudio, or onError on failure.
+    /// </summary>
+    public IEnumerator Synthesize(string text, string voiceId,
+        Action<byte[]> onAudio, Action<string> onError)
+    {
+        if (!HasKey) { onError?.Invoke("no Mistral API key"); yield break; }
+        if (string.IsNullOrEmpty(voiceId)) { onError?.Invoke("no voice id"); yield break; }
+
+        string body = JsonUtility.ToJson(new SpeechRequest
+        {
+            model = k_TtsModel,
+            input = text,
+            voice_id = voiceId,
+            response_format = "mp3"
+        });
+
+        using (var req = new UnityWebRequest(k_SpeechUrl, "POST"))
+        {
+            req.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(body));
+            req.downloadHandler = new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+            req.SetRequestHeader("Authorization", $"Bearer {m_ApiKey}");
+            req.timeout = 30;
+
+            yield return req.SendWebRequest();
+
+            if (req.result != UnityWebRequest.Result.Success)
+            {
+                onError?.Invoke($"tts HTTP {req.responseCode}: {req.error} {req.downloadHandler?.text}");
+                yield break;
+            }
+
+            // Voxtral returns JSON with base64 in `audio_data`. Only treat the body
+            // as raw audio when it is clearly NOT JSON — otherwise a JSON status
+            // payload would be written to the permanent cache as bogus "audio".
+            byte[] audio = null;
+            string raw = req.downloadHandler.text;
+            string ctype = req.GetResponseHeader("Content-Type") ?? "";
+            bool looksJson = ctype.ToLowerInvariant().Contains("json") ||
+                             (!string.IsNullOrEmpty(raw) && raw.TrimStart().StartsWith("{"));
+
+            if (looksJson)
+            {
+                string b64 = null;
+                try { b64 = JsonUtility.FromJson<SpeechResponse>(raw).audio_data; }
+                catch (Exception e) { onError?.Invoke($"tts parse failed: {e.Message}"); yield break; }
+                if (string.IsNullOrEmpty(b64)) { onError?.Invoke($"tts JSON had no audio_data: {Truncate(raw)}"); yield break; }
+                try { audio = Convert.FromBase64String(b64); }
+                catch (Exception e) { onError?.Invoke($"tts base64 decode failed: {e.Message}"); yield break; }
+            }
+            else
+            {
+                audio = req.downloadHandler.data; // genuine binary audio response
+            }
+
+            if (audio == null || audio.Length < 100) { onError?.Invoke("tts returned empty audio"); yield break; }
+            onAudio?.Invoke(audio);
+        }
+    }
+
+    static string Truncate(string s, int max = 200)
+        => string.IsNullOrEmpty(s) ? "" : (s.Length <= max ? s : s.Substring(0, max) + "...");
+
+    [Serializable] struct CloneRequest { public string name; public string sample_audio; public string sample_filename; }
+    [Serializable] struct IdResponse { public string id; }
+    [Serializable] struct SpeechRequest { public string model; public string input; public string voice_id; public string response_format; }
+    [Serializable] struct SpeechResponse { public string audio_data; }
+}

--- a/Assets/VoxtralClient.cs.meta
+++ b/Assets/VoxtralClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 221dcf7c16f2a4550b509fcbf819ff5d

--- a/Assets/WavUtility.cs
+++ b/Assets/WavUtility.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Minimal encoder: Unity float samples -> 16-bit PCM WAV byte buffer.
+/// Used to package a microphone recording for the Voxtral clone endpoint.
+/// </summary>
+public static class WavUtility
+{
+    /// <summary>Encode raw mono/interleaved float samples as a 16-bit PCM WAV.</summary>
+    public static byte[] EncodePcm16(float[] samples, int sampleRate, int channels)
+    {
+        if (samples == null) samples = Array.Empty<float>();
+        int byteRate = sampleRate * channels * 2;
+        int dataSize = samples.Length * 2;
+
+        using (var mem = new MemoryStream(44 + dataSize))
+        using (var w = new BinaryWriter(mem))
+        {
+            // RIFF header
+            w.Write(new[] { 'R', 'I', 'F', 'F' });
+            w.Write(36 + dataSize);
+            w.Write(new[] { 'W', 'A', 'V', 'E' });
+            // fmt chunk
+            w.Write(new[] { 'f', 'm', 't', ' ' });
+            w.Write(16);                 // PCM chunk size
+            w.Write((short)1);           // audio format = PCM
+            w.Write((short)channels);
+            w.Write(sampleRate);
+            w.Write(byteRate);
+            w.Write((short)(channels * 2)); // block align
+            w.Write((short)16);          // bits per sample
+            // data chunk
+            w.Write(new[] { 'd', 'a', 't', 'a' });
+            w.Write(dataSize);
+            for (int i = 0; i < samples.Length; i++)
+            {
+                short s = (short)Mathf.Clamp(Mathf.RoundToInt(samples[i] * 32767f), -32768, 32767);
+                w.Write(s);
+            }
+            w.Flush();
+            return mem.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Extract the recorded portion of a Microphone clip (up to <paramref name="sampleCount"/>
+    /// frames) and encode it as WAV. Pass Microphone.GetPosition() as sampleCount.
+    /// </summary>
+    public static byte[] EncodeFromClip(AudioClip clip, int sampleCount)
+    {
+        if (clip == null) return Array.Empty<byte>();
+        int frames = Mathf.Clamp(sampleCount, 0, clip.samples);
+        if (frames <= 0) frames = clip.samples;
+        var data = new float[frames * clip.channels];
+        clip.GetData(data, 0);
+        return EncodePcm16(data, clip.frequency, clip.channels);
+    }
+}

--- a/Assets/WavUtility.cs.meta
+++ b/Assets/WavUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52ce14b1b835f468e8166c2b68443ef0

--- a/scripts/voice-prep/voxtral_smoke_test.py
+++ b/scripts/voice-prep/voxtral_smoke_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Standalone smoke test for the Mistral Voxtral clone + TTS contract used by the
+Unity VoxtralClient. Verifies the exact endpoints/JSON shapes without Unity.
+
+Usage:
+    export MISTRAL_API_KEY=...            # your key
+    python3 voxtral_smoke_test.py path/to/sample.wav "Round 1. Find the blue pyramid." out.mp3
+
+It will: POST /v1/audio/voices (clone) -> voiceId, then POST /v1/audio/speech
+(voxtral-mini-tts-2603, voice_id) -> write the returned audio to out.mp3.
+
+Only needs `requests`:  pip install requests
+"""
+import base64
+import json
+import os
+import sys
+
+import requests  # type: ignore
+
+BASE = "https://api.mistral.ai/v1"
+TTS_MODEL = "voxtral-mini-tts-2603"
+
+
+def clone(api_key: str, wav_path: str) -> str:
+    with open(wav_path, "rb") as f:
+        sample_b64 = base64.b64encode(f.read()).decode()
+    r = requests.post(
+        f"{BASE}/audio/voices",
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json={"name": "smoke_test", "sample_audio": sample_b64, "sample_filename": os.path.basename(wav_path)},
+        timeout=60,
+    )
+    print(f"clone -> HTTP {r.status_code}")
+    r.raise_for_status()
+    voice_id = r.json().get("id")
+    print(f"voiceId = {voice_id}")
+    if not voice_id:
+        raise SystemExit(f"no voice id in response: {r.text[:400]}")
+    return voice_id
+
+
+def synth(api_key: str, voice_id: str, text: str, out_path: str) -> None:
+    r = requests.post(
+        f"{BASE}/audio/speech",
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json={"model": TTS_MODEL, "input": text, "voice_id": voice_id, "response_format": "mp3"},
+        timeout=30,
+    )
+    print(f"speech -> HTTP {r.status_code}")
+    r.raise_for_status()
+    # Voxtral returns JSON with base64 in `audio_data` (fall back to raw bytes).
+    audio = None
+    ctype = r.headers.get("content-type", "")
+    if "application/json" in ctype or r.text.strip().startswith("{"):
+        audio = base64.b64decode(r.json()["audio_data"])
+    else:
+        audio = r.content
+    with open(out_path, "wb") as f:
+        f.write(audio)
+    print(f"wrote {out_path} ({len(audio)} bytes)")
+
+
+def main() -> None:
+    key = os.environ.get("MISTRAL_API_KEY")
+    if not key:
+        raise SystemExit("set MISTRAL_API_KEY")
+    if len(sys.argv) < 4:
+        raise SystemExit("usage: voxtral_smoke_test.py <sample.wav> <text> <out.mp3>")
+    wav_path, text, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    vid = clone(key, wav_path)
+    synth(key, vid, text, out_path)
+    print("OK — clone + TTS contract verified.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
Adds a new **launch mode** to the gaze-contingency VR app: on entry the participant/researcher chooses **Standard** voice (existing ElevenLabs) or **Self-Similar** voice. Self-Similar records a short mic sample, clones it via **Mistral Voxtral** (`POST /v1/audio/voices`), and synthesizes all assistant speech live from the clone (`POST /v1/audio/speech`), reusing the existing on-disk cache + `AudioSource` playback path.

This implements the *voice* factor of the planned 2×2 (guidance × voice) design.

## Changes
- **SessionConfig** — `VoiceCondition` enum, `Voice`, `SelfSimilarVoiceId`, `SelfSimilarEnrollmentPending`; voice tag added to the run-folder label.
- **VoxtralClient** (new) — clone + TTS, JSON-safe response parsing (won't cache a JSON body as audio).
- **VoiceEnrollment** + **WavUtility** (new) — mic capture → 16-bit PCM WAV → clone; Android mic-permission handling.
- **VoiceModeSelector** (new) — on-entry world-space picker; edge-triggered XR input (Trigger / A) + keyboard `1`/`2` in editor; stays **silent** (not generic) while a clone is still enrolling.
- **VoiceSynthesizer** — branch generic vs self-similar, voice-aware cache key, graceful fallback.
- **VoiceAssistantController** — loads `mistral_key` from `api_keys.json`, wires enrollment + selector.
- **scripts/voice-prep/voxtral_smoke_test.py** (new) — standalone Voxtral clone+TTS contract test.

## Testing
- ✅ Compiles clean in Unity 6000.3.10f1 (Editor import + repo pre-commit compile hook).
- ✅ Code-reviewed; 4 findings fixed (cache-poisoning, held-button auto-select, stale speech context, mixed-voice-while-enrolling).
- ❌ **Not yet run end-to-end** — the record→clone→speak flow needs a microphone, a headset/Play session, and `MISTRAL_API_KEY` (+ `elevenlabs_key`). Run steps are in the code / smoke test.

## ⚠️ IRB
This is the **dev/standalone** path: it puts a Mistral key on the headset and uploads the voice to the cloud, which the approved protocol (offline OpenVoice, no third party, no on-device key) does **not** permit. **Do not use with real participants** without an IRB modification. Fine for dev/testing with the researcher's own voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)